### PR TITLE
feat(alias): add list aliases command

### DIFF
--- a/cmd/alias_list.go
+++ b/cmd/alias_list.go
@@ -1,0 +1,78 @@
+// cmd/alias_list.go
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/msaglietto/mantrid/internal/config"
+	"github.com/msaglietto/mantrid/internal/logging"
+	"github.com/msaglietto/mantrid/internal/paths"
+	"github.com/msaglietto/mantrid/repository/json"
+	"github.com/msaglietto/mantrid/service"
+	"github.com/spf13/cobra"
+)
+
+var listAliasCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all aliases",
+	Long:  `Display a list of all configured aliases with their commands and creation dates.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := logging.GetLogger()
+		ctx := logging.WithLogger(context.Background(), logger)
+
+		logger.Info("listing aliases")
+
+		// Load configuration
+		cfg, err := config.Load()
+		if err != nil {
+			logger.Error("failed to load config", "error", err)
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+
+		// Initialize file manager
+		fm := paths.NewFileManager(cfg)
+
+		// Initialize repository and service
+		repo := json.NewAliasRepository(fm.GetAliasFilePath())
+		svc := service.NewAliasService(repo)
+
+		// Get all aliases
+		aliases, err := svc.ListAliases(ctx)
+		if err != nil {
+			logger.Error("failed to list aliases", "error", err)
+			return fmt.Errorf("failed to list aliases: %w", err)
+		}
+
+		if len(aliases) == 0 {
+			fmt.Println("No aliases found")
+			return nil
+		}
+
+		// Initialize tabwriter for formatted output
+		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(w, "NAME\tCOMMAND\tCREATED\t")
+		fmt.Fprintln(w, "----\t-------\t-------\t")
+
+		for _, alias := range aliases {
+			fmt.Fprintf(w, "%s\t%s\t%s\t\n",
+				alias.Name,
+				alias.Command,
+				formatTime(alias.CreatedAt),
+			)
+		}
+
+		return w.Flush()
+	},
+}
+
+func formatTime(t time.Time) string {
+	return t.Format("2006-01-02 15:04:05")
+}
+
+func init() {
+	aliasCmd.AddCommand(listAliasCmd)
+}

--- a/repository/alias_repository.go
+++ b/repository/alias_repository.go
@@ -9,6 +9,6 @@ import (
 type AliasRepository interface {
 	Save(ctx context.Context, alias *domain.Alias) error
 	FindByName(ctx context.Context, name string) (*domain.Alias, error)
+	List(ctx context.Context) ([]*domain.Alias, error)
 	// Delete(ctx context.Context, name string) error
-	// List(ctx context.Context) ([]*domain.Alias, error)
 }

--- a/repository/json/alias_repository.go
+++ b/repository/json/alias_repository.go
@@ -3,6 +3,7 @@ package json
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -91,4 +92,16 @@ func (r *aliasRepository) writeAliases(aliases []*domain.Alias) error {
 	}
 
 	return os.WriteFile(r.filePath, data, 0644)
+}
+
+func (r *aliasRepository) List(ctx context.Context) ([]*domain.Alias, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	aliases, err := r.readAliases()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read aliases: %w", err)
+	}
+
+	return aliases, nil
 }

--- a/repository/json/alias_repository_test.go
+++ b/repository/json/alias_repository_test.go
@@ -1,0 +1,44 @@
+package json_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/msaglietto/mantrid/domain"
+	"github.com/msaglietto/mantrid/repository/json"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAliasRepository_List(t *testing.T) {
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "aliases.json")
+	repo := json.NewAliasRepository(filePath)
+	ctx := context.Background()
+
+	t.Run("list empty repository", func(t *testing.T) {
+		aliases, err := repo.List(ctx)
+		assert.NoError(t, err)
+		assert.Empty(t, aliases)
+	})
+
+	t.Run("list with aliases", func(t *testing.T) {
+		// Add some test aliases
+		alias1, _ := domain.NewAlias("test1", "echo test1")
+		alias2, _ := domain.NewAlias("test2", "echo test2")
+
+		err := repo.Save(ctx, alias1)
+		assert.NoError(t, err)
+		err = repo.Save(ctx, alias2)
+		assert.NoError(t, err)
+
+		// List aliases
+		aliases, err := repo.List(ctx)
+		assert.NoError(t, err)
+		assert.Len(t, aliases, 2)
+
+		// Verify aliases content
+		assert.Contains(t, []string{aliases[0].Name, aliases[1].Name}, "test1")
+		assert.Contains(t, []string{aliases[0].Name, aliases[1].Name}, "test2")
+	})
+}

--- a/service/alias_service.go
+++ b/service/alias_service.go
@@ -10,6 +10,7 @@ import (
 type AliasService interface {
 	CreateAlias(ctx context.Context, name, command string) error
 	GetAlias(ctx context.Context, name string) (*domain.Alias, error)
+	ListAliases(ctx context.Context) ([]*domain.Alias, error)
 }
 
 type aliasService struct {
@@ -37,4 +38,8 @@ func (s *aliasService) CreateAlias(ctx context.Context, name, command string) er
 
 func (s *aliasService) GetAlias(ctx context.Context, name string) (*domain.Alias, error) {
 	return s.repo.FindByName(ctx, name)
+}
+
+func (s *aliasService) ListAliases(ctx context.Context) ([]*domain.Alias, error) {
+	return s.repo.List(ctx)
 }

--- a/service/alias_service_test.go
+++ b/service/alias_service_test.go
@@ -2,7 +2,9 @@ package service_test
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/msaglietto/mantrid/domain"
 	"github.com/msaglietto/mantrid/service"
@@ -12,6 +14,13 @@ import (
 
 type MockAliasRepository struct {
 	mock.Mock
+}
+
+func cleanupMock(t *testing.T, m *MockAliasRepository) {
+	t.Cleanup(func() {
+		m.ExpectedCalls = nil
+		m.Calls = nil
+	})
 }
 
 func (m *MockAliasRepository) Save(ctx context.Context, alias *domain.Alias) error {
@@ -27,32 +36,85 @@ func (m *MockAliasRepository) FindByName(ctx context.Context, name string) (*dom
 	return args.Get(0).(*domain.Alias), args.Error(1)
 }
 
+func (m *MockAliasRepository) List(ctx context.Context) ([]*domain.Alias, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]*domain.Alias), args.Error(1)
+}
+
 func TestCreateAlias(t *testing.T) {
 	mockRepo := new(MockAliasRepository)
 	service := service.NewAliasService(mockRepo)
 	ctx := context.Background()
 
 	t.Run("create new alias", func(t *testing.T) {
+		cleanupMock(t, mockRepo)
+
 		mockRepo.On("FindByName", ctx, "test").Return(nil, domain.ErrAliasNotFound)
 		mockRepo.On("Save", ctx, mock.AnythingOfType("*domain.Alias")).Return(nil)
 
 		err := service.CreateAlias(ctx, "test", "echo test")
 		assert.NoError(t, err)
 		mockRepo.AssertExpectations(t)
+
 		// Clean up mock after this test case
 		mockRepo.ExpectedCalls = nil
 		mockRepo.Calls = nil
 	})
 
 	t.Run("alias already exists", func(t *testing.T) {
+		cleanupMock(t, mockRepo)
+
 		existingAlias, _ := domain.NewAlias("test", "echo test")
 		mockRepo.On("FindByName", ctx, "test").Return(existingAlias, nil)
 
 		err := service.CreateAlias(ctx, "test", "echo test")
 		assert.Equal(t, domain.ErrAliasExists, err)
 		mockRepo.AssertExpectations(t)
-		// Clean up mock after this test case
-		mockRepo.ExpectedCalls = nil
-		mockRepo.Calls = nil
+	})
+}
+
+func TestListAliases(t *testing.T) {
+	mockRepo := new(MockAliasRepository)
+	service := service.NewAliasService(mockRepo)
+	ctx := context.Background()
+
+	t.Run("list aliases successfully", func(t *testing.T) {
+		cleanupMock(t, mockRepo)
+
+		expectedAliases := []*domain.Alias{
+			{
+				Name:      "test1",
+				Command:   "echo test1",
+				CreatedAt: time.Now(),
+			},
+			{
+				Name:      "test2",
+				Command:   "echo test2",
+				CreatedAt: time.Now(),
+			},
+		}
+
+		mockRepo.On("List", ctx).Return(expectedAliases, nil)
+
+		aliases, err := service.ListAliases(ctx)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedAliases, aliases)
+		assert.Len(t, aliases, 2)
+		mockRepo.AssertExpectations(t)
+	})
+
+	t.Run("list aliases with error", func(t *testing.T) {
+		cleanupMock(t, mockRepo)
+
+		expectedErr := errors.New("failed to list aliases")
+		mockRepo.On("List", ctx).Return(nil, expectedErr)
+
+		aliases, err := service.ListAliases(ctx)
+		assert.Error(t, err)
+		assert.Nil(t, aliases)
+		mockRepo.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
- Add List method to AliasRepository interface
- Implement List method in json repository with tests
- Add ListAliases method to AliasService with tests
- Add list command to CLI with tabulated output
- Clean up mock handling in tests using t.Cleanup

The list command displays all aliases in a formatted table showing name, command, and creation date.